### PR TITLE
Handle URL-only adt_get_source requests gracefully

### DIFF
--- a/src/tools/source.js
+++ b/src/tools/source.js
@@ -285,6 +285,23 @@ export function register({ getClient }) {
       if (typeof args.type !== "string" || args.type.length === 0) {
         return textResult("adt_get_source: `type` is required (e.g. 'class', 'program', 'dataelement').", true);
       }
+
+      if (
+        typeof args.url === "string" &&
+        args.url.length > 0 &&
+        (
+          typeof args.object !== "string" ||
+          args.object.length === 0 ||
+          typeof args.type !== "string" ||
+          args.type.length === 0
+        )
+      ) {
+        return textResult(
+          "adt_get_source currently requires both `object` and `type`. URL-only lookups are not supported.",
+          true
+        );
+      }
+
       const { client, name: sys } = getClient(args.system);
       const t = normalizeType(args.type);
       const path = sourceUri({


### PR DESCRIPTION
## Summary

While investigating issue #18, I noticed that the crash report contained a URL-based request payload rather than the usual `object` + `type` parameters expected by `adt_get_source`.

This change improves validation and error reporting around unsupported request formats.

## Motivation

The reported crash included:

```json
{
  "url": "/sap/bc/adt/oo/classes/.../source/main",
  "system": "E4D"
}
```

Current tool usage expects `object` and `type` parameters. This PR aims to make invalid request formats easier to diagnose and provide clearer feedback to users.

## Notes

I was not able to fully reproduce the original crash on the current main branch, so this change focuses on validation and diagnostics rather than claiming a direct fix.
