### PR TITLE
0.8.58 - clear the open ADT error reports (#104, #106, #109-114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,84 @@ adheres to semantic versioning once it reaches 1.0.0.
 
 ## [Unreleased]
 
+## [0.8.58]
+
+Clearing the open ADT error reports. Two of them were settled by probing a live
+system rather than by reading code, and the probe results are recorded on the
+issues.
+
+### Fixed
+
+- **`adt_list_versions` 406 on every object (#111).** `{objectUri}/versions` is
+  an Atom feed and serves nothing else; the request asked for `application/xml`
+  and the backend answered 406 `ExceptionResourceNotAcceptable` —
+  "Accepted content types: application/atom+xml;type=feed". It now asks for what
+  the endpoint serves, and the parser falls back to reading `<entry>` elements
+  so an Atom-shaped history is returned as version rows rather than raw XML.
+
+- **`adt_compare_versions` 400 on a numeric version (#112).** The ADT `?version=`
+  query only understands `active` and `inactive`; a version number is rejected
+  with `ExceptionParameterValueInvalid`, whose message ("could not be converted")
+  says nothing useful. The tool description no longer claims numeric versions
+  work, and a numeric `from`/`to` is now refused locally with an explanation
+  instead of costing a round trip.
+
+- **Includes could not be activated when they belong to several main programs
+  (#113).** An include compiles only inside a main program, and the activation
+  service gives up with 500 "REPS X is used in multiple master programs" when it
+  has to choose. `adt_activate` now resolves the include's main program and
+  passes it as `?context=`; with exactly one candidate this just works, and with
+  several the tool asks which one, listing them by name, instead of failing.
+  A new `objects[].context` says it up front. The main-program lookup moved from
+  `adt_syntax_check` into a shared module.
+
+- **A function module could not be read without knowing its group (#104).**
+  Function modules are addressed under their function group, which callers
+  rarely have at hand — the module name is what SE37, dumps and where-used lists
+  show. `adt_get_source` and `adt_where_used` now look the group up by
+  repository search (insisting on an exact name match, so a prefix hit can never
+  substitute a different module) and report it back as `resolvedGroup`. When the
+  lookup finds nothing the error points at `adt_search_objects` instead of
+  demanding a value the caller does not have.
+
+- **Adobe forms answered "Unsupported object type" (#109).** Probing a live
+  system showed ADT publishes no source resource for these at all: its discovery
+  document lists 403 collections and none covers `sfp`/`adobe`, and the plausible
+  endpoints all 404. Repository search does know the object, and returns it under
+  the generic workbench bridge
+  (`/sap/bc/adt/vit/wb/object_type/sfpi5i/object_name/…`), which serves object
+  properties — but 404s on `/source/main`. `adt_get_source` now falls back to
+  that bridge and returns the properties with `available: false` and a note that
+  ADT serves no source for the type and the object is edited in SAP GUI. The
+  same bridge covers `SFPF` forms and transactions. The URI cannot be derived
+  from the caller's input (the path needs the TADIR subtype, `SFPI/5I` →
+  `sfpi5i`, while callers pass `SFPI`), hence the search lookup.
+
+- **Opaque backend 500s are now translated (#106, #110).** Some ADT failures name
+  a protocol mistake on the caller's side rather than a backend fault, and left
+  as-is an agent reads them as breakage and retries the identical call.
+  `errorResult` now attaches a hint for these across every tool: *Missing
+  correction number* → no transport was passed on a write; *Missing lock handle*
+  → the stateful lock is gone, re-acquire it in the same session; *…===CCAU does
+  not have any inactive version* → the class simply has no such include.
+
+### Added
+
+- **`adt_where_used` reports the call it made (#114).** The result carries
+  `request` — method, url, query, headers and the mandatory request body — so the
+  underlying ADT call can be replayed by hand in Bruno or curl. Previously the
+  URI-encoded `?uri=` and the request body were invisible to the caller. The
+  field is present on failures too.
+
+### Closed without a change
+
+- **#102** (`TRAN/T`), **#103** (`CLAS/OC`), **#107** (`MSAG/N`), **#108**
+  (`adt_run_unit_tests` crash) — all reported on 0.8.1 and since fixed, or
+  working as intended. **#105** (`adt_get_source` 500 on class test classes) was
+  not reproducible: the class is absent from three systems and reads fine on the
+  one that has it, and a missing class include answers 404 on these releases,
+  not 500.
+
 ## [0.8.57]
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sap-adt-mcp",
-  "version": "0.8.57",
+  "version": "0.8.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sap-adt-mcp",
-      "version": "0.8.57",
+      "version": "0.8.58",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sap-adt-mcp",
-  "version": "0.8.57",
+  "version": "0.8.58",
   "mcpName": "io.github.yzonur/sap-adt-mcp",
   "description": "MCP server giving Claude live access to SAP systems via ADT (ABAP Development Tools) REST. Read source, search, run syntax checks, and edit ABAP objects from any MCP-compatible client.",
   "type": "module",
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "start": "node src/server.js",
-    "test": "node --test test/adt-error.test.js test/atc-bulk.test.js test/audit.test.js test/cds.test.js test/config.test.js test/data-preview.test.js test/debug.test.js test/diff.test.js test/dump-feed.test.js test/grep-source.test.js test/jobs.test.js test/lifecycle-activate.test.js test/lock.test.js test/mcp-bug-fixes.test.js test/node-structure.test.js test/notes.test.js test/object-create.test.js test/object-references.test.js test/object-uris.test.js test/panel.test.js test/prompts.test.js test/provenance.test.js test/query-blank.test.js test/rap-scaffold.test.js test/reporter.test.js test/security.test.js test/source-chunked.test.js test/source-file-io.test.js test/source-guard.test.js test/source-pagination.test.js test/syntax-context.test.js test/tools-shape.test.js test/versions.test.js test/worklist.test.js",
+    "test": "node --test test/adt-error.test.js test/atc-bulk.test.js test/audit.test.js test/cds.test.js test/config.test.js test/data-preview.test.js test/debug.test.js test/diff.test.js test/dump-feed.test.js test/function-modules.test.js test/grep-source.test.js test/jobs.test.js test/lifecycle-activate.test.js test/lock.test.js test/mcp-bug-fixes.test.js test/node-structure.test.js test/notes.test.js test/object-create.test.js test/object-references.test.js test/object-uris.test.js test/panel.test.js test/prompts.test.js test/provenance.test.js test/query-blank.test.js test/rap-scaffold.test.js test/reporter.test.js test/security.test.js test/source-chunked.test.js test/source-file-io.test.js test/source-guard.test.js test/source-pagination.test.js test/syntax-context.test.js test/tools-shape.test.js test/versions.test.js test/workbench-objects.test.js test/worklist.test.js",
     "lint": "eslint src test"
   },
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.yzonur/sap-adt-mcp",
   "description": "Give Claude live access to SAP ABAP via ADT: read, search, check, test, and edit objects.",
-  "version": "0.8.57",
+  "version": "0.8.58",
   "status": "active",
   "repository": {
     "url": "https://github.com/yzonur/sap-adt-mcp",
@@ -12,7 +12,7 @@
     {
       "registryType": "npm",
       "identifier": "sap-adt-mcp",
-      "version": "0.8.57",
+      "version": "0.8.58",
       "transport": {
         "type": "stdio"
       },

--- a/src/adt-error.js
+++ b/src/adt-error.js
@@ -100,6 +100,60 @@ function extractProperties(body) {
   return Object.keys(result).length > 0 ? result : null;
 }
 
+// Some ADT failures arrive as a bare 500 whose message names a *protocol*
+// mistake on our side rather than a backend problem — "Missing correction
+// number" is really "you did not pass a transport", "Missing lock handle" is
+// really "the stateful lock is gone". Left untranslated the agent reads them as
+// backend breakage and retries the same call (#106, #110). Match on the
+// message, not the exception type: the same type covers unrelated failures.
+const ERROR_HINTS = [
+  {
+    match: /missing correction number/i,
+    hint:
+      "The object is under change control and the write carried no transport. Pass `transport` " +
+      "(a modifiable request owned by you — adt_list_transports shows them), or create one with " +
+      "adt_create_transport.",
+  },
+  {
+    match: /missing lock handle/i,
+    hint:
+      "No valid lock handle reached the backend. ADT locks are bound to one stateful session: " +
+      "acquire the lock with adt_lock and use the returned `lockHandle` in the same session. " +
+      "A handle from an earlier session (or one already released) is no longer accepted — " +
+      "call adt_lock again to get a fresh one.",
+  },
+  {
+    // Asking for a class include that does not exist answers with the name of
+    // the generated include (…===CCAU for test classes, ===CCIMP for local
+    // definitions) and a line about inactive versions — which describes the
+    // lookup ADT tried, not the caller's problem. Say what it means.
+    match: /===\w+ does not have any inactive version/i,
+    hint:
+      "That class include does not exist. ADT generates one include per section " +
+      "(===CCAU test classes, ===CCIMP local implementations, ===CCDEF local definitions) " +
+      "and only for the sections the class actually has. Read the class object URI first — " +
+      "its <class:include> entries list which ones are present.",
+  },
+  {
+    match: /is used in multiple master programs/i,
+    hint:
+      "The include belongs to more than one main program, so activation cannot pick a context on " +
+      "its own. Activate the master program instead (pass its name to adt_activate), or pass the " +
+      "include together with the owning program in the same `objects` list.",
+  },
+];
+
+// Best-effort, side-effect-free: returns a caller-facing hint for a parsed ADT
+// error, or undefined when nothing matches.
+export function hintForAdtError(parsed) {
+  if (!parsed) return undefined;
+  const haystack = [parsed.message, parsed.localizedMessage, parsed.properties?.longText]
+    .filter((s) => typeof s === "string" && s.length > 0)
+    .join("\n");
+  if (!haystack) return undefined;
+  return ERROR_HINTS.find((h) => h.match.test(haystack))?.hint;
+}
+
 function stripCData(s) {
   if (!s) return s;
   const trimmed = s.trim();

--- a/src/function-modules.js
+++ b/src/function-modules.js
@@ -1,0 +1,67 @@
+// A function module has no ADT URI of its own — it is addressed as a child of
+// its function group (/functions/groups/<grp>/fmodules/<fm>), so objectUri()
+// refuses to build one without `group`. Callers routinely know only the module
+// name (that is what SE37, dumps and where-used lists show), and got a hard
+// error telling them to supply something they would have to go look up (#104).
+//
+// The RIS quick search already answers the question: searching for the module
+// name returns an objectReference whose URI *contains* the owning group.
+
+import { baseType } from "./object-uris.js";
+import { parseObjectReferences } from "./object-references.js";
+
+// Only the group segment is captured; what follows /fmodules/ is the module
+// name, which the caller already has and which is not always percent-encoded.
+const FMODULE_URI_RE = /\/functions\/groups\/([^/]+)\/fmodules\//i;
+
+// Pull the group out of an ADT function-module URI. Exported for testing and
+// because callers occasionally hold a URI rather than a name.
+export function groupFromFunctionUri(uri) {
+  const m = FMODULE_URI_RE.exec(String(uri ?? ""));
+  return m ? decodeURIComponent(m[1]) : undefined;
+}
+
+// Best-effort lookup of the function group owning `name`. Returns undefined on
+// any failure so the caller can fall back to its original error.
+export async function resolveFunctionGroup(client, name) {
+  if (typeof name !== "string" || name.length === 0) return undefined;
+  try {
+    const res = await client.request({
+      method: "GET",
+      path: "/sap/bc/adt/repository/informationsystem/search",
+      query: { operation: "quickSearch", query: name, maxResults: "10", objectType: "FUGR/FF" },
+    });
+    if (!res.ok) return undefined;
+    const wanted = name.toUpperCase();
+    for (const ref of parseObjectReferences(await res.text())) {
+      // quickSearch matches by prefix, so insist on the exact module before
+      // borrowing its group — a near-miss would silently read another object.
+      if (ref.name && ref.name.toUpperCase() !== wanted) continue;
+      const group = groupFromFunctionUri(ref.uri);
+      if (group) return group;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// The group a caller should use for {type, name}: their own when they supplied
+// one, a looked-up one for a bare function module, and undefined for every
+// other object type (which does not take a group at all). Throwing is left to
+// the URI builders — this only fills in what it can.
+//
+// Returns { group, resolvedGroup } so callers can tell the agent that the group
+// was inferred rather than given.
+export async function resolveGroup(client, { type, name, group }) {
+  if (group || !client) return { group };
+  let t;
+  try {
+    t = baseType(type);
+  } catch {
+    return { group };
+  }
+  if (t !== "FUGR/FF") return { group };
+  const found = await resolveFunctionGroup(client, name);
+  return found ? { group: found, resolvedGroup: true } : { group };
+}

--- a/src/main-programs.js
+++ b/src/main-programs.js
@@ -1,0 +1,62 @@
+// An ABAP include has no identity of its own: it compiles, and activates, only
+// inside a main (master) program. ADT exposes the candidates under
+// {includeObjUri}/mainprograms, and callers pass the chosen one as ?context=.
+//
+// Shared by adt_syntax_check (which needs a context or the check comes back
+// "notProcessed") and adt_activate (which 500s with "REPS X is used in multiple
+// master programs" when the include belongs to more than one, #113).
+
+const REF_RE = /<(?:\w+:)?objectReference\b[^>]*>/gi;
+const BARE_URI_RE = /adtcore:uri="([^"]+)"/gi;
+
+// Normalize a caller-supplied include context into an ADT object URI. Accepts a
+// full ADT path as-is; treats anything else as a program name.
+//
+// A real ADT object URI begins with the ADT path prefix. A *namespaced* ABAP
+// name (e.g. "/FGLR/R_PO_ASSET_CREATE") also begins with "/", so keying on a
+// leading slash alone misclassified it as a ready-made URI and produced an
+// unmappable ?context= → 500 uriMappingError (#67). Only the ADT-path prefix
+// marks a ready URI; every other value — bare or namespaced — is a program name
+// whose slashes must be percent-encoded into the programs URI.
+export function toContextUri(input) {
+  const s = String(input).trim();
+  if (s.startsWith("/sap/bc/adt/")) return s;
+  return `/sap/bc/adt/programs/programs/${encodeURIComponent(s.toLowerCase())}`;
+}
+
+export function parseMainPrograms(xml) {
+  if (typeof xml !== "string") return [];
+  const out = [];
+  for (const m of xml.match(REF_RE) ?? []) {
+    const uri = /adtcore:uri="([^"]+)"/i.exec(m)?.[1];
+    if (!uri) continue;
+    const name = /adtcore:name="([^"]+)"/i.exec(m)?.[1];
+    out.push({ uri: uri.replace(/&amp;/g, "&"), ...(name ? { name } : {}) });
+  }
+  if (out.length) return out;
+  // Older releases wrap the entries in an element we don't recognise; the URIs
+  // are still the only adtcore:uri values in the document.
+  for (const m of xml.matchAll(BARE_URI_RE)) {
+    out.push({ uri: m[1].replace(/&amp;/g, "&") });
+  }
+  return out;
+}
+
+// Best-effort: list an include's main programs via its /mainprograms
+// sub-resource. Any failure (older release, no main program, 4xx) returns an
+// empty list so the caller can degrade instead of blowing up.
+export async function listMainPrograms(client, includeObjUri) {
+  try {
+    const res = await client.request({ path: `${includeObjUri}/mainprograms` });
+    if (!res.ok) return [];
+    return parseMainPrograms(await res.text());
+  } catch {
+    return [];
+  }
+}
+
+// The first main program, or undefined. Kept for callers that only need *a*
+// context and treat ambiguity as acceptable (syntax check).
+export async function deriveMainProgram(client, includeObjUri) {
+  return (await listMainPrograms(client, includeObjUri))[0]?.uri;
+}

--- a/src/result.js
+++ b/src/result.js
@@ -1,4 +1,4 @@
-import { parseAdtError } from "./adt-error.js";
+import { parseAdtError, hintForAdtError } from "./adt-error.js";
 
 export function textResult(text, isError = false) {
   return { content: [{ type: "text", text }], isError };
@@ -10,6 +10,9 @@ export function jsonResult(value, isError = false) {
 
 export function errorResult(system, status, body, contentType, extra = {}) {
   const parsed = parseAdtError(body, contentType);
+  // A caller-side hint when the backend message describes something we asked
+  // for wrongly (missing transport / stale lock handle) rather than a fault.
+  const hint = hintForAdtError(parsed);
   const result = jsonResult(
     {
       system,
@@ -17,6 +20,7 @@ export function errorResult(system, status, body, contentType, extra = {}) {
       ok: false,
       ...extra,
       error: parsed ?? { raw: typeof body === "string" ? body.slice(0, 4000) : body },
+      ...(hint ? { hint } : {}),
     },
     true
   );

--- a/src/tools/discovery.js
+++ b/src/tools/discovery.js
@@ -2,6 +2,7 @@ import { objectUri, sourceUri } from "../object-uris.js";
 import { fetchPackageNodes } from "../node-structure.js";
 import { parseObjectReferences, parseUsageReferences } from "../object-references.js";
 import { errorResult, jsonResult, textResult } from "../result.js";
+import { resolveGroup } from "../function-modules.js";
 import { OBJECT_TYPE_HINT, SYSTEM_HINT } from "./_shared.js";
 
 // Default cap on the where-used list. RIS happily returns five figures of
@@ -114,7 +115,7 @@ export const tools = [
   {
     name: "adt_where_used",
     description:
-      "Where-used list for an object. Returns the references that point to it. Widely-used objects can have thousands of references, so the list is capped at `maxResults` (default 200) — `numberOfResults` always reports the backend's full count and `truncated` says whether the list was cut.",
+      "Where-used list for an object. Returns the references that point to it. Widely-used objects can have thousands of references, so the list is capped at `maxResults` (default 200) — `numberOfResults` always reports the backend's full count and `truncated` says whether the list was cut. The result also carries `request` (method, url, headers, body) so the underlying ADT call can be replayed by hand.",
     inputSchema: {
       type: "object",
       properties: {
@@ -289,13 +290,25 @@ export function register({ getClient }) {
 
     adt_where_used: async (args) => {
       const { client, name: sys } = getClient(args.system);
+      // Function modules are addressed under their group; look it up when the
+      // caller only knows the module name (#104).
+      const { group } = await resolveGroup(client, {
+        type: args.type,
+        name: args.object,
+        group: args.group,
+      });
       let uri;
       try {
-        uri = objectUri({ type: args.type, name: args.object, group: args.group });
+        uri = objectUri({ type: args.type, name: args.object, group });
       } catch (err) {
-        // e.g. a function module (FUGR/FF) passed without its group — objectUri
-        // throws. Return a clean tool error instead of crashing (#74).
-        return textResult(`adt_where_used: ${err.message}`, true);
+        // e.g. a function module (FUGR/FF) whose group was neither supplied nor
+        // resolvable — objectUri throws. Return a clean tool error instead of
+        // crashing (#74).
+        const notFound = /pass 'group'/.test(err.message)
+          ? ` Object search found no function module named '${args.object}' — check the name, ` +
+            "or locate it with adt_search_objects."
+          : "";
+        return textResult(`adt_where_used: ${err.message}.${notFound}`, true);
       }
       // The endpoint requires a real request body with a <usageReferenceRequest>
       // root; the previous empty POST 400'd with "System expected the element
@@ -306,16 +319,29 @@ export function register({ getClient }) {
         `<usagereferences:usageReferenceRequest xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences">` +
         `<usagereferences:affectedObjects/>` +
         `</usagereferences:usageReferenceRequest>`;
-      const res = await client.request({
+      // Echoed back on the result so the exact call can be replayed by hand in
+      // Bruno / curl / the browser — the URI-encoded ?uri= and the mandatory
+      // request body are otherwise invisible to the caller (#114).
+      const request = {
         method: "POST",
         path: "/sap/bc/adt/repository/informationsystem/usageReferences",
         query: { uri },
+        headers: { "Content-Type": "application/*", Accept: "application/*" },
+        body,
+      };
+      request.url = `${request.path}?uri=${encodeURIComponent(uri)}`;
+      const res = await client.request({
+        method: "POST",
+        path: request.path,
+        query: request.query,
         headers: { "Content-Type": "application/*" },
         accept: "application/*",
         body,
       });
       const text = await res.text();
-      if (!res.ok) return errorResult(sys, res.status, text, res.headers.get("content-type"));
+      if (!res.ok) {
+        return errorResult(sys, res.status, text, res.headers.get("content-type"), { request });
+      }
       const refs = parseUsageReferences(text);
       // The backend's own count, from <usageReferenceResult numberOfResults="…">.
       // It differs from refs.length: the parser walks every <adtObject> node,
@@ -337,6 +363,7 @@ export function register({ getClient }) {
           ? { truncated: true, totalParsed: refs.length, maxResults: max }
           : {}),
         references: shown,
+        request,
         raw: refs.length === 0 ? text : undefined,
       });
     },

--- a/src/tools/lifecycle.js
+++ b/src/tools/lifecycle.js
@@ -3,13 +3,14 @@ import { escapeXml } from "../xml.js";
 import { acquireLock, releaseLock } from "../lock.js";
 import { buildCreateRequest, postCreate } from "../object-create.js";
 import { errorResult, jsonResult, textResult } from "../result.js";
+import { toContextUri, listMainPrograms } from "../main-programs.js";
 import { OBJECT_TYPE_HINT, SYSTEM_HINT } from "./_shared.js";
 
 export const tools = [
   {
     name: "adt_activate",
     description:
-      "Activate one or more ABAP objects. In multi-developer scenarios where the object's components are locked in a separate task under the same transport, set processRedoneOOSourceVersionOnly=true to ask SAP to re-activate only the redone OO source versions (bypasses the 'Object components locked in request and separate task' 403).",
+      "Activate one or more ABAP objects. Includes are activated in the context of their main program: the context is auto-resolved, and when the include belongs to several master programs the tool asks which one instead of failing with a 500. In multi-developer scenarios where the object's components are locked in a separate task under the same transport, set processRedoneOOSourceVersionOnly=true to ask SAP to re-activate only the redone OO source versions (bypasses the 'Object components locked in request and separate task' 403).",
     inputSchema: {
       type: "object",
       properties: {
@@ -23,6 +24,11 @@ export const tools = [
               name: { type: "string" },
               type: { type: "string", description: OBJECT_TYPE_HINT },
               group: { type: "string" },
+              context: {
+                type: "string",
+                description:
+                  "For type=include only: the master program to activate it in — a program name or a full ADT object URI. Auto-resolved when the include has exactly one master program.",
+              },
             },
             required: ["name", "type"],
           },
@@ -150,15 +156,43 @@ export function register({ getClient }) {
         }
       }
       const { client, name: sys } = getClient(args.system);
-      const refs = args.objects
-        .map((o) => {
-          const uri = objectUri({ type: o.type, name: o.name, group: o.group });
-          return `<adtcore:objectReference adtcore:uri="${escapeXml(uri)}" adtcore:name="${escapeXml(o.name.toUpperCase())}"/>`;
-        })
-        .join("");
+      const refs = [];
+      for (const o of args.objects) {
+        const uri = objectUri({ type: o.type, name: o.name, group: o.group });
+        // An include compiles only inside a main program. Without a ?context=
+        // the activation service picks one itself and gives up when there is
+        // more than one candidate: 500 "REPS X is used in multiple master
+        // programs" (#113). Resolve it here so the common case just works and
+        // the ambiguous case gets an answerable question instead of a 500.
+        if (normalizeType(o.type) === "INCL") {
+          let context = o.context ? toContextUri(o.context) : undefined;
+          if (!context) {
+            const mains = await listMainPrograms(client, uri);
+            if (mains.length > 1) {
+              return textResult(
+                `adt_activate: include '${o.name}' belongs to ${mains.length} master programs, so ` +
+                  "activation cannot pick a context on its own. Re-run with `context` set to the one " +
+                  `you mean: ${mains.map((m) => m.name ?? m.uri).join(", ")}. ` +
+                  "Activating the master program itself also works.",
+                true
+              );
+            }
+            context = mains[0]?.uri;
+          }
+          refs.push(
+            `<adtcore:objectReference adtcore:uri="${escapeXml(
+              context ? `${uri}?context=${encodeURIComponent(context)}` : uri
+            )}" adtcore:name="${escapeXml(o.name.toUpperCase())}"/>`
+          );
+          continue;
+        }
+        refs.push(
+          `<adtcore:objectReference adtcore:uri="${escapeXml(uri)}" adtcore:name="${escapeXml(o.name.toUpperCase())}"/>`
+        );
+      }
       const body =
         `<?xml version="1.0" encoding="UTF-8"?>` +
-        `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">${refs}</adtcore:objectReferences>`;
+        `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">${refs.join("")}</adtcore:objectReferences>`;
       const preaudit =
         typeof args.preauditRequested === "boolean"
           ? args.preauditRequested

--- a/src/tools/quality.js
+++ b/src/tools/quality.js
@@ -1,6 +1,7 @@
 import { objectUri, sourceUri, normalizeType } from "../object-uris.js";
 import { escapeXml } from "../xml.js";
 import { parseObjectReferences } from "../object-references.js";
+import { toContextUri, deriveMainProgram } from "../main-programs.js";
 import { errorResult, jsonResult, textResult } from "../result.js";
 import { OBJECT_TYPE_HINT, SYSTEM_HINT } from "./_shared.js";
 
@@ -155,35 +156,10 @@ async function runAtcWorklist(client, sys, { uris, checkVariant, maxResults }) {
   };
 }
 
-// Normalize a caller-supplied include context into an ADT object URI. Accepts a
-// full ADT path as-is; treats anything else as a program name.
-//
-// A real ADT object URI begins with the ADT path prefix. A *namespaced* ABAP
-// name (e.g. "/FGLR/R_PO_ASSET_CREATE") also begins with "/", so keying on a
-// leading slash alone misclassified it as a ready-made URI and produced an
-// unmappable ?context= → 500 uriMappingError (#67). Only the ADT-path prefix
-// marks a ready URI; every other value — bare or namespaced — is a program name
-// whose slashes must be percent-encoded into the programs URI.
-export function toContextUri(input) {
-  const s = String(input).trim();
-  if (s.startsWith("/sap/bc/adt/")) return s;
-  return `/sap/bc/adt/programs/programs/${encodeURIComponent(s.toLowerCase())}`;
-}
-
-// Best-effort: resolve an include's first main program via its /mainprograms
-// sub-resource. Any failure (older release, no main program, 4xx) returns
-// undefined so the check still runs (and the response carries a hint).
-async function deriveMainProgram(client, includeObjUri) {
-  try {
-    const res = await client.request({ path: `${includeObjUri}/mainprograms` });
-    if (!res.ok) return undefined;
-    const text = await res.text();
-    const m = text.match(/adtcore:uri="([^"]+)"/i);
-    return m ? m[1].replace(/&amp;/g, "&") : undefined;
-  } catch {
-    return undefined;
-  }
-}
+// Include-context helpers live in ../main-programs.js — adt_activate needs the
+// same resolution (#113). Re-exported so the historical import path keeps
+// working for callers and tests.
+export { toContextUri };
 
 export const tools = [
   {

--- a/src/tools/source.js
+++ b/src/tools/source.js
@@ -3,7 +3,41 @@ import path from "node:path";
 import { sourceUri, objectUri, normalizeType, baseType, METADATA_XML_ACCEPT } from "../object-uris.js";
 import { acquireLock, releaseLock } from "../lock.js";
 import { errorResult, jsonResult, textResult } from "../result.js";
+import { resolveGroup } from "../function-modules.js";
+import {
+  findObjectByName,
+  isWorkbenchUri,
+  fetchWorkbenchProperties,
+  parseObjectProperties,
+} from "../workbench-objects.js";
 import { OBJECT_TYPE_HINT, SYSTEM_HINT } from "./_shared.js";
+
+// Last resort for a type with no source endpoint: ask the repository search
+// what the object actually is, and if it answers with a workbench-bridge URI,
+// return the object properties served there together with a plain statement
+// that ADT has no source document for it (#109). Returns undefined when this
+// is not that situation, so the caller falls through to its own error.
+async function workbenchFallback(client, sys, name) {
+  const found = await findObjectByName(client, name);
+  if (!found || !isWorkbenchUri(found.uri)) return undefined;
+  const res = await fetchWorkbenchProperties(client, found.uri);
+  if (!res.ok) return undefined;
+  return jsonResult({
+    system: sys,
+    object: found.name ?? name,
+    type: found.type,
+    path: found.uri,
+    format: "properties",
+    available: false,
+    properties: parseObjectProperties(res.text),
+    note:
+      `ADT serves no source document for ${found.type} — the type is not in the ADT ` +
+      "discovery document and is reachable only through the generic workbench bridge, " +
+      "which returns object properties (its /source/main is 404). Edit the object in SAP GUI. " +
+      "The properties shown here are everything ADT exposes.",
+    raw: parseObjectProperties(res.text) ? undefined : res.text.slice(0, 4000),
+  });
+}
 
 // Read a local file for a write. The MCP process reads it directly, so a large
 // object's source never has to travel back through the agent's per-call I/O cap
@@ -334,6 +368,13 @@ export function register({ getClient }) {
         );
       }
       const { client, name: sys } = getClient(args.system);
+      // A function module is addressed under its group, which callers usually
+      // don't have at hand — look it up rather than refusing the read (#104).
+      const { group, resolvedGroup } = await resolveGroup(client, {
+        type: args.type,
+        name: args.object,
+        group: args.group,
+      });
       let t;
       let path;
       try {
@@ -343,15 +384,25 @@ export function register({ getClient }) {
         path = sourceUri({
           type: args.type,
           name: args.object,
-          group: args.group,
+          group,
           include: args.include,
         });
       } catch (err) {
         // Unknown/unsupported object types (e.g. WAPA) reach the dispatch
-        // tables and throw. Return that as a clean tool error with an escape
-        // hatch hint instead of letting it surface as a crash.
+        // tables and throw. Before giving up, check whether this is one of the
+        // types ADT serves only through the generic workbench bridge — Adobe
+        // forms, transactions and friends have metadata but no source document
+        // (#109). Returning that beats an "Unsupported object type" dead end.
+        if (!/pass 'group'/.test(err.message)) {
+          const meta = await workbenchFallback(client, sys, args.object);
+          if (meta) return meta;
+        }
+        const notFound = /pass 'group'/.test(err.message)
+          ? ` Object search found no function module named '${args.object}' — check the name, ` +
+            "or locate it with adt_search_objects."
+          : "";
         return textResult(
-          `adt_get_source: ${err.message}. If this type has no high-level mapping yet, ` +
+          `adt_get_source: ${err.message}.${notFound} If this type has no high-level mapping yet, ` +
             `fetch it with adt_request against its ADT source URI.`,
           true
         );
@@ -435,6 +486,9 @@ export function register({ getClient }) {
         system: sys,
         object: args.object,
         type: normalizeType(args.type),
+        // Say so when the function group was looked up rather than supplied —
+        // the caller may want to pass it back on the next call (#104).
+        ...(resolvedGroup ? { group, resolvedGroup: true } : {}),
         path,
         bytes: slice.length,
         lines: sliceLast - sliceFirst + 1,

--- a/src/tools/versions.js
+++ b/src/tools/versions.js
@@ -1,6 +1,6 @@
 import { objectUri, sourceUri, normalizeType } from "../object-uris.js";
 import { unifiedLineDiff } from "../diff.js";
-import { errorResult, jsonResult } from "../result.js";
+import { errorResult, jsonResult, textResult } from "../result.js";
 import { OBJECT_TYPE_HINT, SYSTEM_HINT } from "./_shared.js";
 
 // Parse <vrs:version .../> or generic version entries that some ADT releases
@@ -8,18 +8,56 @@ import { OBJECT_TYPE_HINT, SYSTEM_HINT } from "./_shared.js";
 const VERSION_RE = /<(?:vrs:)?version\b([\s\S]*?)(?:\/>|>)/gi;
 const ATTR_RE = /([\w:.-]+)\s*=\s*"([^"]*)"/g;
 
+// The endpoint answers as an Atom feed (see ACCEPT below), so the version rows
+// arrive as <atom:entry> elements whose payload sits partly in attributes of
+// nested elements and partly in child text. Match the whole entry so both can
+// be harvested (#111).
+const ENTRY_RE = /<(?:\w+:)?entry\b[^>]*>([\s\S]*?)<\/(?:\w+:)?entry>/gi;
+const CHILD_TEXT_RE = /<(?:\w+:)?([\w.-]+)\b[^>]*>([^<]*)<\/(?:\w+:)?[\w.-]+>/g;
+
+function localName(qname) {
+  return qname.replace(/^[\w]+:/, "");
+}
+
 export function parseVersionList(xml) {
   if (typeof xml !== "string") return [];
   const out = [];
   for (const m of xml.matchAll(VERSION_RE)) {
     const attrs = {};
     for (const a of m[1].matchAll(ATTR_RE)) {
-      attrs[a[1].replace(/^[\w]+:/, "")] = a[2];
+      attrs[localName(a[1])] = a[2];
     }
     if (Object.keys(attrs).length) out.push(attrs);
   }
+  if (out.length) return out;
+
+  // Atom-feed shape: one <entry> per version. Collect every attribute found
+  // anywhere inside the entry plus every child element with plain text, so the
+  // caller sees the version number / user / timestamp whatever the release
+  // decided to call them. Last write wins — attributes are the more specific
+  // carrier, so they are read after the child text.
+  for (const e of xml.matchAll(ENTRY_RE)) {
+    const inner = e[1];
+    const row = {};
+    for (const c of inner.matchAll(CHILD_TEXT_RE)) {
+      const value = c[2].trim();
+      if (value) row[localName(c[1])] = value;
+    }
+    for (const a of inner.matchAll(ATTR_RE)) {
+      const key = localName(a[1]);
+      // Namespace declarations are noise, not version data.
+      if (key === "xmlns" || a[1].startsWith("xmlns:")) continue;
+      row[key] = a[2];
+    }
+    if (Object.keys(row).length) out.push(row);
+  }
   return out;
 }
+
+// {objectUri}/versions is an Atom feed and nothing else: asking for
+// "application/xml" makes it answer 406 ExceptionResourceNotAcceptable with
+// "Accepted content types: application/atom+xml;type=feed" (#111).
+export const VERSIONS_ACCEPT = "application/atom+xml;type=feed";
 
 export const tools = [
   {
@@ -40,7 +78,7 @@ export const tools = [
   {
     name: "adt_compare_versions",
     description:
-      "Diff two versions of the SAME object's source within one system. Defaults to active-vs-inactive (the daily 'what did I change but not yet activate' question). Pass from/to to compare specific version identifiers understood by the ADT ?version= query (e.g. 'active', 'inactive', or a numeric version number where supported). Returns a unified diff plus added/removed line counts, reusing the same diff engine as adt_compare_source.",
+      "Diff two versions of the SAME object's source within one system. Defaults to active-vs-inactive (the daily 'what did I change but not yet activate' question). from/to are passed to the ADT ?version= query, which only understands the symbolic values 'active' and 'inactive' — a numeric version number is rejected with 400 ExceptionParameterValueInvalid. Returns a unified diff plus added/removed line counts, reusing the same diff engine as adt_compare_source.",
     inputSchema: {
       type: "object",
       properties: {
@@ -51,11 +89,11 @@ export const tools = [
         include: { type: "string", description: "For classes: which include to compare." },
         from: {
           type: "string",
-          description: "Base version passed to ?version= (default 'inactive').",
+          description: "Base version passed to ?version= — 'active' or 'inactive' (default 'inactive').",
         },
         to: {
           type: "string",
-          description: "Target version passed to ?version= (default 'active').",
+          description: "Target version passed to ?version= — 'active' or 'inactive' (default 'active').",
         },
         context: {
           type: "integer",
@@ -76,7 +114,7 @@ export function register({ getClient }) {
       const objUri = objectUri({ type: args.type, name: args.object, group: args.group });
       const res = await client.request({
         path: `${objUri}/versions`,
-        accept: "application/xml",
+        accept: VERSIONS_ACCEPT,
       });
       const text = await res.text();
       if (res.status === 404) {
@@ -104,9 +142,25 @@ export function register({ getClient }) {
     },
 
     adt_compare_versions: async (args) => {
-      const { client, name: sys } = getClient(args.system);
       const from = args.from ?? "inactive";
       const to = args.to ?? "active";
+      // ?version= takes symbolic values only. A numeric identifier read off a
+      // version history 400s server-side with an opaque "could not be
+      // converted" message (#112); say so here instead of paying a round trip.
+      const numeric = [
+        ["from", from],
+        ["to", to],
+      ].find(([, v]) => /^\d+$/.test(String(v).trim()));
+      if (numeric) {
+        return textResult(
+          `adt_compare_versions: \`${numeric[0]}\` = '${numeric[1]}' — the ADT ?version= query only accepts ` +
+            "'active' or 'inactive'. A numeric version number is rejected by the backend with " +
+            "400 ExceptionParameterValueInvalid. To inspect older revisions use adt_list_versions " +
+            "and follow the version's own URI.",
+          true
+        );
+      }
+      const { client, name: sys } = getClient(args.system);
       const path = sourceUri({
         type: args.type,
         name: args.object,

--- a/src/workbench-objects.js
+++ b/src/workbench-objects.js
@@ -1,0 +1,90 @@
+// ADT publishes only part of the repository as first-class REST resources. Its
+// discovery document lists 403 collections and none of them covers Adobe forms
+// (SFPF/SFPI) or transactions (TRAN) — probing /sap/bc/adt/sfp/... returns 404
+// ExceptionResourceNotFound.
+//
+// Such objects are still reachable, through the generic workbench bridge:
+//
+//   /sap/bc/adt/vit/wb/object_type/<type><subtype>/object_name/<NAME>
+//
+// which answers 200 with application/vnd.sap.adt.basic.object.properties+xml —
+// an <adtcore:mainObject> carrying responsible / master language / package /
+// description / timestamps. What it does *not* have is source: the same URI
+// with /source/main appended returns 404 "No suitable resource found".
+//
+// So for these types the honest answer is "ADT has metadata but no source
+// document; the object is edited in SAP GUI" — which is a far better result
+// than the bare "Unsupported object type" crash the caller used to get (#109).
+//
+// The URI cannot be derived from the caller's input: the path segment needs the
+// TADIR *subtype* (SFPI/5I → sfpi5i, SFPF/5F → sfpf5f, TRAN/T → trant), and
+// callers legitimately pass the bare type ("SFPI"). The repository search knows
+// the full type, and returns exactly this URI — so ask it rather than guess.
+
+import { parseObjectReferences } from "./object-references.js";
+
+const WB_URI_RE = /\/vit\/wb\/object_type\/([^/]+)\/object_name\//i;
+
+export function isWorkbenchUri(uri) {
+  return WB_URI_RE.test(String(uri ?? ""));
+}
+
+// Look the object up by name and hand back what the repository says it is.
+// Returns { uri, type, name, description, packageName } or undefined — never
+// throws, so callers can treat it as a best-effort enrichment.
+export async function findObjectByName(client, name) {
+  if (!client || typeof name !== "string" || name.length === 0) return undefined;
+  try {
+    const res = await client.request({
+      method: "GET",
+      path: "/sap/bc/adt/repository/informationsystem/search",
+      query: { operation: "quickSearch", query: name, maxResults: "10" },
+    });
+    if (!res.ok) return undefined;
+    const wanted = name.toUpperCase();
+    // quickSearch matches by prefix — insist on the exact name so a near-miss
+    // never gets read in place of the object that was asked for.
+    const hit = parseObjectReferences(await res.text()).find(
+      (r) => r.name && r.name.toUpperCase() === wanted && r.uri
+    );
+    if (!hit) return undefined;
+    return {
+      uri: hit.uri,
+      type: hit.type,
+      name: hit.name,
+      description: hit.description,
+      packageName: hit.packageName,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+const PROPS_ACCEPT = "application/vnd.sap.adt.basic.object.properties+xml";
+
+// Fetch the workbench object-properties document for `uri`. Returns
+// { ok, status, text } so the caller can surface a failure verbatim.
+export async function fetchWorkbenchProperties(client, uri) {
+  const res = await client.request({ path: uri, accept: PROPS_ACCEPT });
+  const text = await res.text();
+  return { ok: res.ok, status: res.status, text, contentType: res.headers.get("content-type") };
+}
+
+// Pull the interesting attributes out of <adtcore:mainObject …/>, so the caller
+// gets structured data instead of a wall of XML.
+const ATTR_RE = /([\w:.-]+)\s*=\s*"([^"]*)"/g;
+
+export function parseObjectProperties(xml) {
+  if (typeof xml !== "string") return undefined;
+  const m = /<(?:\w+:)?mainObject\b([^>]*)>/i.exec(xml);
+  if (!m) return undefined;
+  const out = {};
+  for (const a of m[1].matchAll(ATTR_RE)) {
+    const key = a[1].replace(/^adtcore:/, "");
+    if (key.startsWith("xmlns")) continue;
+    out[key] = a[2];
+  }
+  const pkg = /<(?:\w+:)?packageRef\b[^>]*adtcore:name="([^"]+)"/i.exec(xml);
+  if (pkg) out.package = pkg[1];
+  return Object.keys(out).length ? out : undefined;
+}

--- a/test/adt-error.test.js
+++ b/test/adt-error.test.js
@@ -1,6 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseAdtError } from "../src/adt-error.js";
+import { parseAdtError, hintForAdtError } from "../src/adt-error.js";
+import { errorResult } from "../src/result.js";
+
+const envelope = (type, message) => `<?xml version="1.0" encoding="UTF-8"?>
+<exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communication">
+  <namespace id="com.sap.adt.functions"/>
+  <type id="${type}"/>
+  <message lang="EN">${message}</message>
+</exc:exception>`;
 
 const SAMPLE_ENVELOPE = `<?xml version="1.0" encoding="UTF-8"?>
 <exc:exception xmlns:exc="http://www.sap.com/abapxml/types/communication">
@@ -9,6 +17,56 @@ const SAMPLE_ENVELOPE = `<?xml version="1.0" encoding="UTF-8"?>
   <message lang="EN">Object ZFOO does not exist</message>
   <localizedMessage lang="EN">Object ZFOO does not exist (localized)</localizedMessage>
 </exc:exception>`;
+
+// ─── #106 / #110 / #113: opaque 500s translated into an actionable hint ────────
+
+test("hintForAdtError: 'Missing correction number' points at the transport — #106", () => {
+  const parsed = parseAdtError(
+    envelope("ExceptionDuringFunctionGroupSerialization", "Missing correction number"),
+    "application/xml"
+  );
+  assert.match(hintForAdtError(parsed), /transport/i);
+  assert.match(hintForAdtError(parsed), /adt_create_transport/);
+});
+
+test("hintForAdtError: 'Missing lock handle' points at re-locking — #110", () => {
+  const parsed = parseAdtError(
+    envelope("ExceptionDuringFunctionGroupSerialization", "Missing lock handle"),
+    "application/xml"
+  );
+  assert.match(hintForAdtError(parsed), /adt_lock/);
+  assert.match(hintForAdtError(parsed), /stateful session/i);
+});
+
+test("hintForAdtError: multiple master programs points at the include context — #113", () => {
+  const parsed = parseAdtError(
+    envelope("ExceptionActivationServiceFailure", "REPS ZHURECINBOUND_TOP is used in multiple master programs"),
+    "application/xml"
+  );
+  assert.match(hintForAdtError(parsed), /adt_activate/);
+});
+
+test("hintForAdtError: an unremarkable failure gets no hint", () => {
+  const parsed = parseAdtError(SAMPLE_ENVELOPE, "application/xml");
+  assert.equal(hintForAdtError(parsed), undefined);
+  assert.equal(hintForAdtError(null), undefined);
+});
+
+test("errorResult carries the hint alongside the parsed error", () => {
+  const r = errorResult(
+    "FAKE",
+    500,
+    envelope("ExceptionDuringFunctionGroupSerialization", "Missing correction number"),
+    "application/xml"
+  );
+  const out = JSON.parse(r.content[0].text);
+  assert.equal(r.isError, true);
+  assert.match(out.hint, /transport/i);
+  assert.equal(out.error.message, "Missing correction number");
+
+  const plain = JSON.parse(errorResult("FAKE", 500, SAMPLE_ENVELOPE, "application/xml").content[0].text);
+  assert.equal(plain.hint, undefined, "no hint invented for ordinary failures");
+});
 
 test("parses the standard ADT exception envelope", () => {
   const r = parseAdtError(SAMPLE_ENVELOPE, "application/xml");

--- a/test/function-modules.test.js
+++ b/test/function-modules.test.js
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  groupFromFunctionUri,
+  resolveFunctionGroup,
+  resolveGroup,
+} from "../src/function-modules.js";
+
+const hit = (name, group) => ({
+  ok: true,
+  status: 200,
+  headers: { get: () => "application/xml" },
+  text: async () =>
+    '<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">' +
+    `<adtcore:objectReference adtcore:uri="/sap/bc/adt/functions/groups/${group}/fmodules/${encodeURIComponent(name.toLowerCase())}"` +
+    ` adtcore:name="${name}" adtcore:type="FUGR/FF"/>` +
+    "</adtcore:objectReferences>",
+});
+
+const empty = {
+  ok: true,
+  status: 200,
+  headers: { get: () => "application/xml" },
+  text: async () => '<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"/>',
+};
+
+function fakeClient(response) {
+  const calls = [];
+  return {
+    calls,
+    request: async (call) => {
+      calls.push(call);
+      return response;
+    },
+  };
+}
+
+test("groupFromFunctionUri: extracts and decodes the owning group", () => {
+  assert.equal(groupFromFunctionUri("/sap/bc/adt/functions/groups/v61a/fmodules/rv_price"), "v61a");
+  assert.equal(
+    groupFromFunctionUri("/sap/bc/adt/functions/groups/%2Ffglr%2Fdelivery/fmodules/x"),
+    "/fglr/delivery"
+  );
+  assert.equal(groupFromFunctionUri("/sap/bc/adt/oo/classes/zcl_a"), undefined);
+  assert.equal(groupFromFunctionUri(undefined), undefined);
+});
+
+test("resolveFunctionGroup: finds the group by object search — #104", async () => {
+  const client = fakeClient(hit("/FGLR/FM_CREATE_GR_FR01", "%2Ffglr%2Fcreate"));
+  const group = await resolveFunctionGroup(client, "/FGLR/FM_CREATE_GR_FR01");
+  assert.equal(group, "/fglr/create");
+  assert.equal(client.calls[0].query.objectType, "FUGR/FF");
+  assert.equal(client.calls[0].query.query, "/FGLR/FM_CREATE_GR_FR01");
+});
+
+test("resolveFunctionGroup: a prefix match is not accepted as the module — #104", async () => {
+  // quickSearch matches by prefix; borrowing the group of a different module
+  // would silently read the wrong object.
+  const client = fakeClient(hit("/FGLR/FM_CREATE_GR_FR01_OLD", "%2Ffglr%2Fother"));
+  assert.equal(await resolveFunctionGroup(client, "/FGLR/FM_CREATE_GR_FR01"), undefined);
+});
+
+test("resolveFunctionGroup: no hit and transport failures degrade to undefined", async () => {
+  assert.equal(await resolveFunctionGroup(fakeClient(empty), "Z_NOPE"), undefined);
+  const boom = {
+    request: async () => {
+      throw new Error("socket hang up");
+    },
+  };
+  assert.equal(await resolveFunctionGroup(boom, "Z_NOPE"), undefined);
+  assert.equal(await resolveFunctionGroup(fakeClient(empty), ""), undefined);
+});
+
+test("resolveGroup: only a group-less function module triggers a lookup — #104", async () => {
+  const supplied = fakeClient(hit("Z_FM", "zgrp"));
+  assert.deepEqual(await resolveGroup(supplied, { type: "function", name: "Z_FM", group: "ZOTHER" }), {
+    group: "ZOTHER",
+  });
+  assert.equal(supplied.calls.length, 0, "a supplied group is never second-guessed");
+
+  const other = fakeClient(hit("Z_FM", "zgrp"));
+  assert.deepEqual(await resolveGroup(other, { type: "class", name: "ZCL_A" }), { group: undefined });
+  assert.equal(other.calls.length, 0, "non-function types don't take a group at all");
+
+  const bare = fakeClient(hit("Z_FM", "zgrp"));
+  assert.deepEqual(await resolveGroup(bare, { type: "function", name: "Z_FM" }), {
+    group: "zgrp",
+    resolvedGroup: true,
+  });
+});
+
+test("resolveGroup: an unparseable type is left to the URI builder to reject", async () => {
+  const client = fakeClient(empty);
+  assert.deepEqual(await resolveGroup(client, { type: "", name: "Z_FM" }), { group: undefined });
+  assert.equal(client.calls.length, 0);
+});

--- a/test/lifecycle-activate.test.js
+++ b/test/lifecycle-activate.test.js
@@ -3,13 +3,15 @@ import assert from "node:assert/strict";
 
 import { register } from "../src/tools/lifecycle.js";
 
-function makeCtx() {
+function makeCtx({ responses } = {}) {
   const calls = [];
+  let i = 0;
   const ctx = {
     getClient: () => ({
       client: {
         request: async (call) => {
           calls.push(call);
+          if (responses && i < responses.length) return responses[i++];
           return {
             ok: true,
             status: 200,
@@ -58,6 +60,67 @@ test("adt_activate allows preauditRequested override to false", async () => {
     preauditRequested: false,
   });
   assert.equal(calls[0].query.preauditRequested, "false");
+});
+
+// ─── #113: includes activate inside a master program ──────────────────────────
+
+const mainProgramsFeed = (...names) => ({
+  ok: true,
+  status: 200,
+  headers: { get: () => "application/xml" },
+  text: async () =>
+    '<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">' +
+    names
+      .map(
+        (n) =>
+          `<adtcore:objectReference adtcore:uri="/sap/bc/adt/programs/programs/${n.toLowerCase()}" adtcore:name="${n}"/>`
+      )
+      .join("") +
+    "</adtcore:objectReferences>",
+});
+
+test("adt_activate: a single master program is resolved into ?context= — #113", async () => {
+  const { ctx, calls } = makeCtx({ responses: [mainProgramsFeed("ZHURECINBOUND")] });
+  const handlers = register(ctx);
+  await handlers.adt_activate({ objects: [{ name: "ZHURECINBOUND_TOP", type: "include" }] });
+
+  assert.match(calls[0].path, /\/programs\/includes\/zhurecinbound_top\/mainprograms$/);
+  const activation = calls[1];
+  assert.equal(activation.path, "/sap/bc/adt/activation");
+  assert.match(
+    activation.body,
+    /programs\/includes\/zhurecinbound_top\?context=%2Fsap%2Fbc%2Fadt%2Fprograms%2Fprograms%2Fzhurecinbound/
+  );
+});
+
+test("adt_activate: an ambiguous include asks which master program — #113", async () => {
+  const { ctx, calls } = makeCtx({ responses: [mainProgramsFeed("ZMAIN_A", "ZMAIN_B")] });
+  const handlers = register(ctx);
+  const r = await handlers.adt_activate({
+    objects: [{ name: "ZHURECINBOUND_TOP", type: "include" }],
+  });
+  assert.equal(r.isError, true);
+  assert.match(r.content[0].text, /2 master programs/);
+  assert.match(r.content[0].text, /ZMAIN_A, ZMAIN_B/);
+  assert.equal(calls.length, 1, "must not attempt the activation it knows will 500");
+});
+
+test("adt_activate: an explicit context skips resolution — #113", async () => {
+  const { ctx, calls } = makeCtx();
+  const handlers = register(ctx);
+  await handlers.adt_activate({
+    objects: [{ name: "ZHURECINBOUND_TOP", type: "include", context: "ZMAIN_B" }],
+  });
+  assert.equal(calls.length, 1, "no /mainprograms lookup when the caller already said which");
+  assert.match(calls[0].body, /context=%2Fsap%2Fbc%2Fadt%2Fprograms%2Fprograms%2Fzmain_b/);
+});
+
+test("adt_activate: a non-include is untouched by context resolution — #113", async () => {
+  const { ctx, calls } = makeCtx();
+  const handlers = register(ctx);
+  await handlers.adt_activate({ objects: [{ name: "ZCL_FOO", type: "CLAS" }] });
+  assert.equal(calls.length, 1);
+  assert.doesNotMatch(calls[0].body, /context=/);
 });
 
 test("adt_activate omits isProcessRedoneOOSourceVerOnly when flag is false", async () => {

--- a/test/mcp-bug-fixes.test.js
+++ b/test/mcp-bug-fixes.test.js
@@ -251,12 +251,58 @@ test("adt_where_used: reports the backend's own count and caps the list (#99)", 
   assert.equal(trimmed.numberOfResults, 2);
 });
 
-test("adt_where_used: a function module without group returns a clean error, not a crash (#74)", async () => {
+test("adt_where_used: echoes the raw ADT call so it can be replayed (#114)", async () => {
+  const { ctx } = makeCtx();
+  const h = registerDiscovery(ctx);
+  const out = JSON.parse(
+    (await h.adt_where_used({ object: "/FGLR/CL_EQUIPMENT_MAIN", type: "class" })).content[0].text
+  );
+  assert.equal(out.request.method, "POST");
+  assert.equal(out.request.path, "/sap/bc/adt/repository/informationsystem/usageReferences");
+  assert.equal(out.request.query.uri, "/sap/bc/adt/oo/classes/%2Ffglr%2Fcl_equipment_main");
+  // The replayable URL must carry the ?uri= value encoded exactly once more,
+  // the way the client puts it on the wire.
+  assert.equal(
+    out.request.url,
+    "/sap/bc/adt/repository/informationsystem/usageReferences" +
+      "?uri=%2Fsap%2Fbc%2Fadt%2Foo%2Fclasses%2F%252Ffglr%252Fcl_equipment_main"
+  );
+  assert.match(out.request.body, /usageReferenceRequest/);
+  assert.equal(out.request.headers["Content-Type"], "application/*");
+});
+
+test("adt_where_used: a function module whose group can't be found errors cleanly, no crash (#74)", async () => {
+  // The mock search answers with nothing, so the group stays unknown.
   const { ctx, calls } = makeCtx();
   const h = registerDiscovery(ctx);
   const r = await h.adt_where_used({ object: "/FGLR/DELIVERY_CREATE", type: "FUGR/FF" });
   assert.match(r.content[0].text, /pass 'group'/);
-  assert.equal(calls.length, 0, "must not issue a request when the URI can't be built");
+  assert.match(r.content[0].text, /adt_search_objects/);
+  assert.equal(
+    calls.filter((c) => c.path.includes("usageReferences")).length,
+    0,
+    "must not issue the where-used call when the URI can't be built"
+  );
+});
+
+test("adt_where_used: a bare function module resolves its group by search (#104)", async () => {
+  const searchHit = {
+    ok: true,
+    status: 200,
+    headers: { get: () => "application/xml" },
+    text: async () =>
+      '<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">' +
+      '<adtcore:objectReference adtcore:uri="/sap/bc/adt/functions/groups/%2Ffglr%2Fdelivery/fmodules/%2Ffglr%2Fdelivery_create"' +
+      ' adtcore:name="/FGLR/DELIVERY_CREATE" adtcore:type="FUGR/FF"/>' +
+      "</adtcore:objectReferences>",
+  };
+  const { ctx, calls } = makeCtx({ responses: [searchHit] });
+  const h = registerDiscovery(ctx);
+  const r = await h.adt_where_used({ object: "/FGLR/DELIVERY_CREATE", type: "FUGR/FF" });
+  assert.notEqual(r.isError, true);
+  const whereUsed = calls.find((c) => c.path.includes("usageReferences"));
+  assert.ok(whereUsed, "the where-used call must happen once the group is known");
+  assert.match(whereUsed.query.uri, /groups\/%2Ffglr%2Fdelivery\/fmodules\//);
 });
 
 // ─── Bug B: adt_read_table sends the data-preview table Accept header ──────────

--- a/test/versions.test.js
+++ b/test/versions.test.js
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { register, parseVersionList } from "../src/tools/versions.js";
+import { register, parseVersionList, VERSIONS_ACCEPT } from "../src/tools/versions.js";
 
 function makeCtx({ responses } = {}) {
   const calls = [];
@@ -86,6 +86,43 @@ test("adt_compare_versions: identical sources → identical:true", async () => {
   const r = await h.adt_compare_versions({ object: "ZCL_A", type: "class", from: "active", to: "active" });
   const out = JSON.parse(r.content[0].text);
   assert.equal(out.identical, true);
+});
+
+test("parseVersionList: falls back to atom entries — #111", () => {
+  const xml =
+    '<atom:feed xmlns:atom="http://www.w3.org/2005/Atom">' +
+    '<atom:entry><atom:title>000002</atom:title>' +
+    '<atom:link href="/sap/bc/adt/vit/versions/2" rel="self"/>' +
+    "<adtcore:author>DEV</adtcore:author></atom:entry>" +
+    '<atom:entry><atom:title>000001</atom:title>' +
+    "<adtcore:author>DEV2</adtcore:author></atom:entry>" +
+    "</atom:feed>";
+  const v = parseVersionList(xml);
+  assert.equal(v.length, 2);
+  assert.equal(v[0].title, "000002");
+  assert.equal(v[0].author, "DEV");
+  assert.equal(v[0].href, "/sap/bc/adt/vit/versions/2");
+  assert.equal(v[1].author, "DEV2");
+  // xmlns declarations are noise and must not leak into the version rows.
+  assert.equal(v[0].xmlns, undefined);
+});
+
+test("adt_list_versions: asks for the atom feed the endpoint serves — #111", async () => {
+  const { ctx, calls } = makeCtx({ responses: [resp("<atom:feed/>")] });
+  const h = register(ctx);
+  await h.adt_list_versions({ object: "ZI_A", type: "cds" });
+  assert.equal(calls[0].accept, VERSIONS_ACCEPT);
+  assert.match(calls[0].accept, /atom\+xml/);
+});
+
+test("adt_compare_versions: numeric version is rejected before the round trip — #112", async () => {
+  const { ctx, calls } = makeCtx({ responses: [resp("x"), resp("y")] });
+  const h = register(ctx);
+  const r = await h.adt_compare_versions({ object: "ZI_A", type: "cds", from: "1", to: "active" });
+  assert.equal(r.isError, true);
+  assert.match(r.content[0].text, /only accepts/);
+  assert.match(r.content[0].text, /`from`/);
+  assert.equal(calls.length, 0);
 });
 
 test("adt_compare_versions: from-side fetch error is surfaced with side label", async () => {

--- a/test/workbench-objects.test.js
+++ b/test/workbench-objects.test.js
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { register } from "../src/tools/source.js";
+import {
+  isWorkbenchUri,
+  parseObjectProperties,
+  findObjectByName,
+} from "../src/workbench-objects.js";
+
+// Shapes taken verbatim from a probe against a live system (#109).
+const SFPI_URI =
+  "/sap/bc/adt/vit/wb/object_type/sfpi5i/object_name/%2fFGLR%2fAI_RENTAL_RETURN";
+
+const SEARCH_HIT = {
+  ok: true,
+  status: 200,
+  headers: { get: () => "application/xml" },
+  text: async () =>
+    '<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">' +
+    `<adtcore:objectReference adtcore:uri="${SFPI_URI}" adtcore:type="SFPI/5I"` +
+    ' adtcore:name="/FGLR/AI_RENTAL_RETURN" adtcore:description="FIT Rent Return Interface"/>' +
+    "</adtcore:objectReferences>",
+};
+
+const PROPERTIES = {
+  ok: true,
+  status: 200,
+  headers: { get: () => "application/vnd.sap.adt.basic.object.properties+xml" },
+  text: async () =>
+    '<adtcore:mainObject xmlns:adtcore="http://www.sap.com/adt/core" adtcore:responsible="X-KILGIN"' +
+    ' adtcore:masterLanguage="EN" adtcore:masterSystem="E4D" adtcore:name="/FGLR/AI_RENTAL_RETURN"' +
+    ' adtcore:type="SFPI/5I" adtcore:version="active" adtcore:description="FIT Rent Return Interface">' +
+    '<adtcore:packageRef adtcore:uri="/sap/bc/adt/packages/%2ffglr%2fprints" adtcore:type="DEVC/K"' +
+    ' adtcore:name="/FGLR/PRINTS"/></adtcore:mainObject>',
+};
+
+const NOTHING = {
+  ok: true,
+  status: 200,
+  headers: { get: () => "application/xml" },
+  text: async () => '<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"/>',
+};
+
+function makeCtx(responses) {
+  const calls = [];
+  let i = 0;
+  return {
+    calls,
+    ctx: {
+      getClient: () => ({
+        client: {
+          request: async (call) => {
+            calls.push(call);
+            return responses[i++] ?? NOTHING;
+          },
+        },
+        name: "E4T",
+        profile: { user: "TESTER" },
+      }),
+      config: { systems: {}, defaultSystem: null },
+    },
+  };
+}
+
+test("isWorkbenchUri recognises the generic workbench bridge", () => {
+  assert.equal(isWorkbenchUri(SFPI_URI), true);
+  assert.equal(isWorkbenchUri("/sap/bc/adt/vit/wb/object_type/trant/object_name/ZPROC"), true);
+  assert.equal(isWorkbenchUri("/sap/bc/adt/oo/classes/zcl_a"), false);
+  assert.equal(isWorkbenchUri(undefined), false);
+});
+
+test("parseObjectProperties lifts the mainObject attributes and its package", async () => {
+  const p = parseObjectProperties(await PROPERTIES.text());
+  assert.equal(p.name, "/FGLR/AI_RENTAL_RETURN");
+  assert.equal(p.type, "SFPI/5I");
+  assert.equal(p.responsible, "X-KILGIN");
+  assert.equal(p.masterSystem, "E4D");
+  assert.equal(p.package, "/FGLR/PRINTS");
+  assert.equal(parseObjectProperties("<nothing/>"), undefined);
+});
+
+test("findObjectByName: a prefix match is not accepted as the object", async () => {
+  const { ctx } = makeCtx([SEARCH_HIT]);
+  const { client } = ctx.getClient();
+  assert.equal(await findObjectByName(client, "/FGLR/AI_RENTAL"), undefined);
+});
+
+test("adt_get_source: an SFPI returns workbench properties, not 'Unsupported object type' — #109", async () => {
+  const { ctx } = makeCtx([SEARCH_HIT, PROPERTIES]);
+  const r = await register(ctx).adt_get_source({
+    object: "/FGLR/AI_RENTAL_RETURN",
+    type: "SFPI",
+    system: "E4T",
+  });
+  assert.notEqual(r.isError, true);
+  const out = JSON.parse(r.content[0].text);
+  assert.equal(out.available, false);
+  assert.equal(out.type, "SFPI/5I");
+  assert.equal(out.path, SFPI_URI);
+  assert.equal(out.properties.package, "/FGLR/PRINTS");
+  assert.match(out.note, /no source document/i);
+  assert.match(out.note, /SAP GUI/);
+  assert.equal(out.source, undefined, "there is no source to report");
+});
+
+test("adt_get_source: an unknown type the search can't place still errors — #109", async () => {
+  const { ctx } = makeCtx([NOTHING]);
+  const r = await register(ctx).adt_get_source({ object: "ZNOPE", type: "WAPA" });
+  assert.equal(r.isError, true);
+  assert.match(r.content[0].text, /Unsupported object type/);
+  assert.match(r.content[0].text, /adt_request/);
+});


### PR DESCRIPTION
Clears the open ADT error reports. Two of them were settled by probing a live system rather than by reading code; those probe results are recorded on the issues themselves.

## Fixed

**#111 — `adt_list_versions` 406 on every object.** `{objectUri}/versions` is an Atom feed and serves nothing else; the request asked for `application/xml`, so the backend answered 406 with "Accepted content types: application/atom+xml;type=feed". Now asks for what the endpoint serves, and the parser falls back to reading `<entry>` elements so an Atom-shaped history comes back as version rows instead of raw XML.

**#112 — `adt_compare_versions` 400 on a numeric version.** `?version=` only understands `active` / `inactive`. The tool description claimed numeric versions worked "where supported"; it no longer does, and a numeric `from`/`to` is refused locally with an explanation rather than costing a round trip for an opaque `ExceptionParameterValueInvalid`.

**#113 — includes could not be activated when they belong to several main programs.** An include compiles only inside a main program, and the activation service gives up with 500 *"REPS X is used in multiple master programs"* when it has to choose. `adt_activate` now resolves the main program and passes it as `?context=`. One candidate → it just works; several → the tool asks which one, listing them by name, instead of failing. New `objects[].context` states it up front. The lookup moved out of `adt_syntax_check` into a shared module.

**#104 — a function module could not be read without knowing its group.** Function modules are addressed under their group, which callers rarely have — the module name is what SE37, dumps and where-used lists show. `adt_get_source` and `adt_where_used` now look it up by repository search and report it back as `resolvedGroup`. An exact name match is required, so a prefix hit can never substitute a different module. When nothing is found the error points at `adt_search_objects`.

**#109 — Adobe forms answered "Unsupported object type".** Probing showed ADT publishes no source resource for these at all: the discovery document lists 403 collections and none covers `sfp`/`adobe`, and the plausible endpoints all 404. Repository search does know the object and returns it under the generic workbench bridge (`/sap/bc/adt/vit/wb/object_type/sfpi5i/object_name/…`), which serves object properties but 404s on `/source/main`. `adt_get_source` now falls back there and returns the properties with `available: false` plus a note that no source document exists and the object is edited in SAP GUI. Same bridge covers `SFPF` forms and transactions.

The URI cannot be derived from the caller's input — the path segment needs the TADIR subtype (`SFPI/5I` → `sfpi5i`) while callers pass the bare type (`SFPI`, as in the report) — hence the search lookup rather than a constructed path.

**#106 / #110 — opaque backend 500s are now translated.** Some ADT failures name a protocol mistake on our side rather than a backend fault; left as-is, an agent reads them as breakage and retries the identical call. `errorResult` now attaches a hint across every tool: *Missing correction number* → no transport on a write; *Missing lock handle* → the stateful lock is gone, re-acquire in the same session; *…===CCAU does not have any inactive version* → the class has no such include.

## Added

**#114 — `adt_where_used` reports the call it made.** The result carries `request` (method, url, query, headers, body) so the underlying ADT call can be replayed by hand in Bruno or curl; the URI-encoded `?uri=` and the mandatory request body were previously invisible. Present on failures too.

## Closed without a change

#102 (`TRAN/T`), #103 (`CLAS/OC`), #107 (`MSAG/N`), #108 (`adt_run_unit_tests` crash) — all reported on 0.8.1 and since fixed, or working as intended. #105 was not reproducible: the class is absent from three systems and reads fine on the one that has it, and a missing class include answers 404 on these releases, not 500.

## Verification

344 tests pass, lint clean. New coverage for the Atom fallback and accept header, the numeric-version guard, include context resolution (single / ambiguous / explicit / non-include), function-group resolution including the prefix-match rejection, the workbench fallback, and the error hints.

Note that #111, #113 and #104 are verified by unit tests only — they have not run against a live system yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
